### PR TITLE
Made maven deploy the unshaded jar as main jar, shaded now secondary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.mingweisamuel.zyra</groupId>
     <artifactId>zyra</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0-RC1</version>
+    <version>2.0.1-RC1</version>
 
     <name>zyra</name>
     <description>Riot Games League of Legends API Library for Java</description>
@@ -193,24 +193,21 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- http://stackoverflow.com/a/574650/2398020 -->
-                <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.0</version>
                 <executions>
                     <execution>
-                        <id>assembly</id>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
                         <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>standalone-full</shadedClassifierName>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <finalName>${project.build.finalName}-standalone-full</finalName>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.github.wvengen</groupId>


### PR DESCRIPTION
The pom.xml was configured to deploy the shaded jar to the repositories, causing the classes of the maven dependencies to be contained in the jar; they are not needed there, since maven provides the dependencies. The dependencies are only needed in the standalone-jars, which are not supposed to be used by maven, but by people that directly add dependency jars to their projects.

The usage of the fat jar in maven can cause problems with duplicate classes, for example SLF4J gave warnings to me in my project, because I use the SLF4J binding logback, but the fat jar included another binding (which I couldn't exclude using maven, since it is contained in the jar directly, and I can't simply exclude the whole artifact) that caused conflicts.

In this pull-request I changed the jar that is deployed to the maven repository to be the barebone-jar without the dependencies. I did this by using the maven shade-plugin that generates an additonal fat-jar and doesn't cause the fat-jar to be deployed to the maven repository instead of the simple jar.