### PR TITLE
Update search.maven.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zyra
 
 [![Travis](https://img.shields.io/travis/MingweiSamuel/Zyra/develop.svg?style=flat-square)](https://travis-ci.org/MingweiSamuel/Zyra)
-[![Maven](https://img.shields.io/maven-central/v/com.mingweisamuel.zyra/zyra.svg?style=flat-square&label=maven)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.mingweisamuel.zyra%22%20AND%20a%3A%22zyra%22)
+[![Maven](https://img.shields.io/maven-central/v/com.mingweisamuel.zyra/zyra.svg?style=flat-square&label=maven)](https://search.maven.org/search?q=g:com.mingweisamuel.zyra%20AND%20a:zyra)
 [![Javadoc Stable](https://www.javadoc.io/badge/com.mingweisamuel.zyra/zyra.svg?style=flat-square)](https://www.javadoc.io/doc/com.mingweisamuel.zyra/zyra)
 
 


### PR DESCRIPTION
search.maven.org just updated, breaking old links to fixed searched. I was updating the one for Orianna on riot-api-libs forums post and updated Zyra's as well. Figured I'd throw a PR in over here to for completeness.